### PR TITLE
Fixing require order: config class must be loaded before notifiers

### DIFF
--- a/lib/uptime_checker.rb
+++ b/lib/uptime_checker.rb
@@ -8,7 +8,7 @@ require "erb"
 require "yaml"
 
 def require_dir(dir)
-  Dir["#{dir}/**/*.rb"].each do |file|
+  Dir["#{dir}/**/*.rb"].sort.each do |file|
     require file
   end
 end


### PR DESCRIPTION
Hello,

Trying to run on my standalone Debian 8.x machine I got the following:

```
$ bundle exec ruby ./lib/uptime_checker.rb
/home/user/uptime_checker/lib/uptime_checker/notifier/slack.rb:10:in `enabled?': uninitialized constant UptimeChecker::Notifier::Slack::Config (NameError)
Did you mean?  RbConfig
        from /home/user/uptime_checker/lib/uptime_checker/notifier.rb:5:in `select'
        from /home/user/uptime_checker/lib/uptime_checker/notifier.rb:5:in `<module:Notifier>'
        from /home/user/uptime_checker/lib/uptime_checker/notifier.rb:2:in `<module:UptimeChecker>'
        from /home/user/uptime_checker/lib/uptime_checker/notifier.rb:1:in `<top (required)>'
        from /home/user/uptime_checker/lib/uptime_checker.rb:12:in `require'
        from /home/user/uptime_checker/lib/uptime_checker.rb:12:in `block in require_dir'
        from /home/user/uptime_checker/lib/uptime_checker.rb:11:in `each'
        from /home/user/uptime_checker/lib/uptime_checker.rb:11:in `require_dir'
        from /home/user/uptime_checker/lib/uptime_checker.rb:17:in `<top (required)>'
        from ./lib/uptime_checker.rb:12:in `require'
        from ./lib/uptime_checker.rb:12:in `block in require_dir'
        from ./lib/uptime_checker.rb:11:in `each'
        from ./lib/uptime_checker.rb:11:in `require_dir'
        from ./lib/uptime_checker.rb:17:in `<main>'
```

Maybe the Config class must be loaded before Notifiers?
