### PR TITLE
[Fix] Color notify on slack and the order that uptime retrieves state

### DIFF
--- a/lib/uptime_checker/checker.rb
+++ b/lib/uptime_checker/checker.rb
@@ -37,8 +37,8 @@ module UptimeChecker
       UptimeChecker.log message: "check started",
                         url: url
 
-      previous_state = retrieve_previous_state
       current_state = retrieve_current_state
+      previous_state = retrieve_previous_state
       transition = Transition.new(previous_state, current_state)
 
       store.set(key, transition.state)

--- a/lib/uptime_checker/locales/pt-BR.yml
+++ b/lib/uptime_checker/locales/pt-BR.yml
@@ -6,6 +6,10 @@ pt-BR:
   second:
     one: 1 segundo
     other: "%{count} segundos"
+    
+  hour:
+    one: 1 hora
+    other: "%{count} horas"
 
   day:
     one: 1 dia

--- a/lib/uptime_checker/notifier/slack.rb
+++ b/lib/uptime_checker/notifier/slack.rb
@@ -2,8 +2,8 @@ module UptimeChecker
   module Notifier
     class Slack
       COLORS = {
-        green: "good",
-        red: "danger"
+        "green" => "good",
+        "red" => "danger"
       }
 
       def self.enabled?

--- a/lib/uptime_checker/notifier/slack.rb
+++ b/lib/uptime_checker/notifier/slack.rb
@@ -30,7 +30,11 @@ module UptimeChecker
           }])
         }
 
-        HttpClient.post("https://slack.com/api/chat.postMessage", params)
+        res = HttpClient.post("https://slack.com/api/chat.postMessage", params)
+        body = JSON.parse(res.body) rescue nil
+        if !body || !body["ok"]
+          puts "Slack API failed: #{res.inspect} #{body}"
+        end
       end
     end
   end


### PR DESCRIPTION
It wasn't coloring the slack notification.

Sometimes it notifies twice since the retrieve from the redis is faster than the current_state.
